### PR TITLE
Fix: ispaused() function

### DIFF
--- a/pomo.sh
+++ b/pomo.sh
@@ -63,7 +63,7 @@ function pomo_stop {
 function pomo_ispaused {
     # Return 0 if paused, 1 otherwise.
     # pomo.sh is paused if the POMO file contains any information.
-    [[ $(wc -l "$POMO" | sed 's/^ *//' | cut -d" " -f1) -gt 0 ]]
+    [[ $(wc -l < "$POMO") -gt 0 ]]
     return $?
 }
 

--- a/pomo.sh
+++ b/pomo.sh
@@ -63,7 +63,7 @@ function pomo_stop {
 function pomo_ispaused {
     # Return 0 if paused, 1 otherwise.
     # pomo.sh is paused if the POMO file contains any information.
-    [[ $(wc -l "$POMO" | cut -d" " -f1) -gt 0 ]]
+    [[ $(wc -l "$POMO" | sed 's/^ *//' | cut -d" " -f1) -gt 0 ]]
     return $?
 }
 


### PR DESCRIPTION
In some versions of wc, the wc -l output contains leading whitespace, which subsequently messes up the test for a line count of greater than zero. In case the wc -l output contains leading whitespace, the function ispaused() never returns 0.