### PR TITLE
Add additional status bars to Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,7 @@ Add pomo as a new polybar module to your polybar config::
     type = custom/script
     interval = 1
     exec = pomo.sh clock
+    click-left = pomo.sh pause
 
 
 Then add it to your module definition, e.g. ::

--- a/README.rst
+++ b/README.rst
@@ -73,19 +73,40 @@ using notification-daemon and send-notify.  This involves pomo.sh sleeping until
 
 $ pomo.sh notify &
 
-The clock command is ideal for running from inside xmobar, e.g. in the xmobar
-configuration file::
+Status Bars
+-----------
+
+The clock command is ideal for integrating `pomo.sh` with various status bars. Some examples can be found below.
+
+xmobar
+******
+
+Add the following to your xmobar configuration::
 
     Config {
-        commands = [
-            -- rest of commands
-            , Run Com "pomo.sh" ["clock"] "pomo" 10"
-            ]
-        -- rest of config
+       commands = [
+          ...
+          , Run Com "pomo.sh" ["clock"] "pomo" "10"
+       ]
     }
 
 The output of the clock command can then be inserted into the xmobar template
 using ``%pomo%``.
+
+polybar
+^^^^^^
+
+Add pomo as a new polybar module to your polybar config::
+
+    [module/pomo]
+    type = custom/script
+    interval = 1
+    exec = pomo.sh clock
+
+
+Then add it to your module definition, e.g. ::
+
+    modules-right = date pomo
 
 Dependencies
 ------------


### PR DESCRIPTION
First off, great work. Most of the other Pomodoro CLIs out there are overkill. This is nice and simple, just as it should be.

I was thinking about writing a simple shell Pomodoro tracker myself, but luckily I found this :smile: 

I'm using Polybar, and I thought it might be useful for others to add a section on how to integrate `pomo.sh` with it as well. 