### PR TITLE
better notify-send usage

### DIFF
--- a/pomo.sh
+++ b/pomo.sh
@@ -201,7 +201,7 @@ function send_msg {
     if [ "$(uname)" == "Darwin" ]; then
         osascript -e "tell app \"System Events\" to display dialog \"${1}\"" &> /dev/null
     elif command -v notify-send &> /dev/null; then
-        notify-send Pomodoro "${1}"
+        notify-send -a "Pomodoro" "${1}"
     else
         echo "${1}"
     fi

--- a/tests/pomo_test.bats
+++ b/tests/pomo_test.bats
@@ -37,6 +37,10 @@ function _pomo_msg_helper() {
 # Mocks
 function notify-send() {
     # Mock notify-send to echo.
+    # We set the app-name to notify send using -a, which is not a valid option
+    # for echo. Remove the flag and pass everything (app name and message) to
+    # echo.
+    shift
     echo "$@"
 }
 


### PR DESCRIPTION
Currently, the notify-send command shows notification like this.. (shows 'notify-send' as app name)
![Screenshot_20220215_190608](https://user-images.githubusercontent.com/27774996/154072831-2bd3f866-a0f8-4212-bb58-3db674e61da1.png)


My merge request makes it look like so.. (app name becomes "Pomodoro")
![Screenshot_20220215_190626](https://user-images.githubusercontent.com/27774996/154072982-48e618a8-ce49-4593-98ac-29bcc4afd3ad.png)