### PR TITLE
Added -p to mkdir to resolve non-existing .local

### DIFF
--- a/pomo.sh
+++ b/pomo.sh
@@ -43,7 +43,7 @@ fi
 
 function pomo_start {
     # Start new pomo block (work+break cycle).
-    test -e "$(dirname -- "$POMO")" || mkdir "$(dirname -- "$POMO")"
+    test -e "$(dirname -- "$POMO")" || mkdir -p "$(dirname -- "$POMO")"
     :> "$POMO" # remove saved time stamp due to a pause.
     touch "$POMO"
 }


### PR DESCRIPTION
If the $HOME/.local directory does not exist, this error is encountered (as I did on my mac). Adding -p to resolve this issue

mkdir: /Users/macuser/.local: No such file or directory
./pomo.sh: line 47: /Users/macuser/.local/share/pomo: No such file or directory
touch: /Users/macuser/.local/share/pomo: No such file or directory