### PR TITLE
Add default XDG_CONFIG_HOME directory location

### DIFF
--- a/pomo.sh
+++ b/pomo.sh
@@ -277,7 +277,8 @@ END
 #--- Command-line interface ---
 
 action=
-config=${POMO_CONFIG:-"$XDG_CONFIG_HOME/pomo.cfg"}
+config_home=${XDG_CONFIG_HOME:-"$HOME/.config"}
+config=${POMO_CONFIG:-"$config_home/pomo.cfg"}
 while getopts "hc:" arg; do
     case $arg in
 	c)


### PR DESCRIPTION
Makes `$HOME/.config` the default configuration directory.

Fixes #12 