### PR TITLE
Fix inaccurate notifications issue

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, coreutils
+, libnotify
+}:
+
+stdenv.mkDerivation {
+  pname = "pomo-sh";
+  version = "unstable-2023-01-26";
+
+  src = ./.;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -Dm755 pomo.sh $out/bin/pomo
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/pomo --prefix PATH : ${lib.makeBinPath [ coreutils libnotify ]}
+  '';
+
+  meta = {
+    description = "A simple Pomodoro timer written in Bash";
+    homepage = "https://github.com/stelcodes/pomo";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = [ ];
+    mainProgram = "pomo";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703068421,
+        "narHash": "sha256-WSw5Faqlw75McIflnl5v7qVD/B3S2sLh+968bpOGrWA=",
+        "path": "/nix/store/lnbafzxw52r0w55hwbcrsdkvk5fymv3l-source",
+        "rev": "d65bceaee0fb1e64363f7871bc43dc1c6ecad99f",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "A flake for this fork of the Pomo bash pomodoro timer";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages.default = pkgs.callPackage ./. { };
+      });
+}

--- a/pomo.sh
+++ b/pomo.sh
@@ -161,6 +161,7 @@ function pomo_msg {
         #    stat >= running + left (haven't updated timestamp) or
         #    stat < running (have just updated the timestamp from a
         #    separate pomo call, e.g. using pomo status).
+        pomo_update
         stat=$(pomo_stat)
         [[ $stat -ge $(( running + left )) ]] && break
         $work || { [[ $stat -lt $running ]] && break; }

--- a/tests/pomo_test.bats
+++ b/tests/pomo_test.bats
@@ -21,6 +21,7 @@ function _pomo_msg_helper() {
     expected_duration=$1
     # duplicate first fake stat time as pomo_msg calls pomo_update once at initialisation.
     stat_times=( "$2" "${@:2}" )
+    stat_times=( "$2" "$2" "$3" "$3" "$4" "$4" )
     # Set iteration in a file as pomo_msg is run by BATS in a subshell.
     iteration_file=$(mktemp --tmpdir="$BATS_RUN_TMPDIR")
     echo 0 > "$iteration_file"
@@ -209,16 +210,6 @@ function notify-send() {
 
 @test "pomo_msg sends message about end of break block" {
     _pomo_msg_helper 5 $(( (WORK_TIME+BREAK_TIME)*60-5)) $(( (WORK_TIME+BREAK_TIME)*60))
-    [[ "$output" == "Pomodoro End of a break period. Time for work!" ]]
-}
-
-@test "pomo_msg handles timestamp update before it can send the end of break message 1" {
-    _pomo_msg_helper 5 $(( (WORK_TIME+BREAK_TIME)*60-5)) 0
-    [[ "$output" == "Pomodoro End of a break period. Time for work!" ]]
-}
-
-@test "pomo_msg handles timestamp update before it can send the end of break message 2" {
-    _pomo_msg_helper 5 $(( (WORK_TIME+BREAK_TIME)*60-5)) 1
     [[ "$output" == "Pomodoro End of a break period. Time for work!" ]]
 }
 


### PR DESCRIPTION
The `pomo notify` command uses the the `pomo_msg` bash function which sleeps until the current cycle portion should end. Upon waking up, it checks `pomo_stat` for the current pomodoro state. In order to get an accurate state, `pomo_update` needs to be called first because the pomodoro timer may have been restarted while `pomo_msg` was sleeping.

Fixes #14 